### PR TITLE
Allow multiple lib directories to be passed (bug fix)

### DIFF
--- a/src/runwar/Start.java
+++ b/src/runwar/Start.java
@@ -584,9 +584,14 @@ public class Start {
 		    	background = Boolean.valueOf(line.getOptionValue("background"));
 		    }
 		    if (line.hasOption("libs")) {
-                File lib = new File(line.getOptionValue("libs"));
-                if (!lib.exists() || !lib.isDirectory())
-                	printUsage("No such lib directory "+lib,1);
+		    	String[] list = line.getOptionValue("libs").split(",");
+
+		    	for (String path : list) {
+                	File lib = new File(path);
+	                if (!lib.exists() || !lib.isDirectory())
+	                	printUsage("No such lib directory "+path,1);
+		    	}               
+                
                 libDirs = line.getOptionValue("libs");
             }
 


### PR DESCRIPTION
Previously, there were some validation checks on the input that was expecting only a single lib directory. This now loops over multiple after splitting the input on a comma
