### PR TITLE
Split JVM Args on non-escaped semicolons

### DIFF
--- a/src/runwar/options/CommandLineHandler.java
+++ b/src/runwar/options/CommandLineHandler.java
@@ -753,9 +753,9 @@ public class CommandLineHandler {
             }
             if (line.hasOption("jvmargs") && line.getOptionValue("jvmargs").length() > 0) {
                 List<String> jvmArgs = new ArrayList<String>();
-                String[] jvmArgArray = line.getOptionValue("jvmargs").split(";");
+                String[] jvmArgArray = serverConfig.getOptionValue("jvmargs").split("(?<!\\\\);");
                 for(String arg : jvmArgArray) {
-                    jvmArgs.add(arg);
+                    jvmArgs.add(arg.replaceAll("\\\\;", ";"));
                 }
                 serverOptions.setJVMArgs(jvmArgs);
             }

--- a/src/runwar/options/ConfigParser.java
+++ b/src/runwar/options/ConfigParser.java
@@ -290,7 +290,7 @@ public class ConfigParser {
             }
             if (serverConfig.hasOption("jvmargs") && serverConfig.getOptionValue("jvmargs").length() > 0) {
                 List<String> jvmArgs = new ArrayList<String>();
-                String[] jvmArgArray = serverConfig.getOptionValue("jvmargs").split(";");
+                String[] jvmArgArray = serverConfig.getOptionValue("jvmargs").split("(?<!\\);");
                 for(String arg : jvmArgArray) {
                     jvmArgs.add(arg);
                 }

--- a/src/runwar/options/ConfigParser.java
+++ b/src/runwar/options/ConfigParser.java
@@ -290,9 +290,9 @@ public class ConfigParser {
             }
             if (serverConfig.hasOption("jvmargs") && serverConfig.getOptionValue("jvmargs").length() > 0) {
                 List<String> jvmArgs = new ArrayList<String>();
-                String[] jvmArgArray = serverConfig.getOptionValue("jvmargs").split("(?<!\\);");
+                String[] jvmArgArray = serverConfig.getOptionValue("jvmargs").split("(?<!\\\\);");
                 for(String arg : jvmArgArray) {
-                    jvmArgs.add(arg);
+                    jvmArgs.add(arg.replaceAll("\\\\;", ";"));
                 }
                 serverOptions.setJVMArgs(jvmArgs);
             }


### PR DESCRIPTION
Currently, there is no way to include a semicolon in a JVM argument because all semicolons are split.  This change makes it so escaped semicolons (`\;`) are not split.